### PR TITLE
Dispatch connection failed event

### DIFF
--- a/decs.d.ts
+++ b/decs.d.ts
@@ -5,6 +5,7 @@ declare module 'protoo-client' {
     origin?: string;
     headers?: http.OutgoingHttpHeaders;
     requestOptions?: object;
+    retry?: object;
   }
   export class WebSocketTransport {
     constructor(url: string, options?: ProtooOptions);

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,12 +57,17 @@ export default class Client extends EventEmitter {
 
     this.dispatch.on('disconnected', () => {
       log.info('Peer "disconnected" event');
-      this.emit('transport-failed');
+      this.emit('transport-disconnected');
     });
 
     this.dispatch.on('close', () => {
       log.info('Peer "close" event');
       this.emit('transport-closed');
+    });
+
+    this.dispatch.on('failed', (currentAttempt: number) => {
+      log.info('Peer "failed" event');
+      this.emit('transport-failed', currentAttempt)
     });
 
     this.dispatch.on('request', this.onRequest);
@@ -93,7 +98,7 @@ export default class Client extends EventEmitter {
       log.info('join success: result => ' + JSON.stringify(data));
     } catch (error) {
       log.error('join reject: error =>' + error);
-      throw error  
+      throw error
     }
   }
 


### PR DESCRIPTION
- When weboscket fails to connect first time, 'failed' event is triggered. All subsequent failed retries will trigger 'failed' event as well. Once all retry count has been exhausted (using exponential backoff), a 'closed' event is triggered. 
- In a case where WebSocket was already connected to remote host, the 'disconnect' event will be triggered instead of 'failed'. 
- Add retry options for WebSocket to client