### PR TITLE
Small fix for loosing remote streams

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -177,6 +177,7 @@ export default class Client extends EventEmitter {
         connected = connected && !failedStatuses.includes(state);
       } else {
         log.warn("Ice connection state is invalid")
+        connected = false
       }
     })
     return connected
@@ -218,6 +219,7 @@ export default class Client extends EventEmitter {
         const stream = this.streams[mid!];
         this.emit('stream-remove', stream, uid);
         stream.close();
+        delete this.streams[mid!]
         break;
       }
       case 'broadcast': {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -204,7 +204,7 @@ export class LocalStream extends Stream {
     this.transport.oniceconnectionstatechange = async () => {
       const state = this.transport?.getPeerConnection()?.iceConnectionState || undefined;
       if (state) {
-        log.debug('Ice connection state for sender changed to: '+state);
+        log.debug(`Ice connection state for sender ${this.mid} changed to: ${state}`);
         if (this.onStreamConnectionStateChange && this.mid) {
           this.onStreamConnectionStateChange(this.mid, !(["closed", "disconnected", "failed"].includes(state)))
         }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -274,7 +274,7 @@ export class RemoteStream extends Stream {
       }
     };
     transport.oniceconnectionstatechange = async () => {
-      log.debug('Ice connection state for receiver changed to: '+ transport?.getPeerConnection().iceConnectionState)
+      log.debug(`Ice connection state for receiver ${mid} changed to: ${transport?.getPeerConnection().iceConnectionState}`)
     };
     const stream: MediaStream = await new Promise(async (resolve, reject) => {
       try {


### PR DESCRIPTION
Going baby steps here. Looked at Ken's log what happened and with this patch, it should, in theory, prevent an issue where we lose some of the remote streams on network blip. This will cause a full reload when that happens, so not ideal. Since I can't reproduce this with my setup, I want to check if this solves the problem first. If it does, maybe trying to re-subscribe to lost streams could be a better solution with less overhead. 